### PR TITLE
fix: thanos: enable thanos discovery sidecar service in kps

### DIFF
--- a/cluster-apps/chongus/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/cluster-apps/chongus/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -173,13 +173,19 @@ spec:
               resources:
                 requests:
                   storage: 55Gi
+        walCompression: true
         thanos:
           objectStorageConfig:
             secret:
               type: s3
               config:
                 insecure: true
-        walCompression: true
+
+      thanosService:
+        enabled: true
+      thanosServiceMonitor:
+        enabled: true
+
       route:
         main:
           enabled: true


### PR DESCRIPTION
Thanos uses the discovery sidecar to collect endpoints to query from the query service.