### PR TITLE
ignore clsuter-cd for lints given it's being deprecated

### DIFF
--- a/.github/lint/.yamllint.yaml
+++ b/.github/lint/.yamllint.yaml
@@ -9,7 +9,10 @@ ignore: |
   *.cho-raw.yaml
   *.sid.yaml
   *.sid-raw.yaml
-  cluster-cd/apps/bitty/downloads/qbittorrent/tools/resources/config.yaml
+  *.bty.yaml
+  cluster-cd/
+  ansible/
+  clusters/bitty/
 extends: default
 rules:
   truthy:

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -1,3 +1,4 @@
+---
 name: On PR
 
 on:


### PR DESCRIPTION
Signed-off-by: Russell Troxel <russell@troxel.io>
