### PR TITLE
feat(qbittorrent): persist mousehole state in config PVC subPath

### DIFF
--- a/cluster-apps/chongus/downloads/qbittorrent/app/helmrelease.yaml
+++ b/cluster-apps/chongus/downloads/qbittorrent/app/helmrelease.yaml
@@ -167,6 +167,9 @@ spec:
           qbittorrent:
             app:
               - path: /config
+            mousehole:
+              - path: /srv/mousehole
+                subPath: mousehole
       media:
         type: nfs
         server: nas.rtrox.io
@@ -184,9 +187,3 @@ spec:
           qbittorrent:
             gluetun:
               - path: /gluetun
-      mousehole-data:
-        type: emptyDir
-        advancedMounts:
-          qbittorrent:
-            mousehole:
-              - path: /srv/mousehole


### PR DESCRIPTION
## Summary

- Replaces the ephemeral `mousehole-data` emptyDir volume with a subPath mount (`mousehole/`) inside the existing qbittorrent config PVC
- Mousehole state at `/srv/mousehole` now persists across pod restarts

## Test plan

- [ ] Verify pod starts successfully and mousehole container mounts `/srv/mousehole`
- [ ] Confirm `/config/mousehole` directory is created on the PVC
- [ ] Verify mousehole state persists after a pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)