### PR TITLE
fix(envoy-gateway): skip CRD management to prevent gateway-api downgrade

### DIFF
--- a/cluster-apps/base/envoy-gateway/app/helmrelease.yaml
+++ b/cluster-apps/base/envoy-gateway/app/helmrelease.yaml
@@ -10,9 +10,9 @@ spec:
     kind: OCIRepository
     name: envoy-gateway
   install:
-    crds: CreateReplace
+    crds: Skip
   upgrade:
-    crds: CreateReplace
+    crds: Skip
   values:
     config:
       envoyGateway:

--- a/cluster-apps/base/envoy-gateway/app/helmrelease.yaml
+++ b/cluster-apps/base/envoy-gateway/app/helmrelease.yaml
@@ -9,6 +9,9 @@ spec:
   chartRef:
     kind: OCIRepository
     name: envoy-gateway
+  # Gateway API CRDs are managed by the bootstrap helmfile (gateway-api-crds v1.5.1).
+  # That chart installs safe-upgrades ValidatingAdmissionPolicy which blocks downgrading
+  # CRDs below v1.5.0, so we must not let this chart manage them.
   install:
     crds: Skip
   upgrade:


### PR DESCRIPTION
## Summary

- Bootstrap (`helmfile.d/00-crds.yaml`) installs Gateway API CRDs at **v1.5.1** via the `gateway-api-crds` chart
- `gateway-api-crds` v1.5.1 installs the `safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy, which blocks any attempt to downgrade Gateway API CRDs below v1.5.0
- `envoy-gateway` chart 1.7.2 bundles older Gateway API CRDs and was trying to apply them with `crds: CreateReplace`, triggering the policy on every upgrade

**Fix:** Change `install.crds` and `upgrade.crds` from `CreateReplace` to `Skip` so Helm leaves the bootstrap-managed CRDs alone.

## Test plan

- [ ] `envoy-gateway` HelmRelease reconciles successfully after this change
- [ ] Gateway API CRDs remain at v1.5.x (unchanged from bootstrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)