### PR TITLE
fix(spegel): force upgrade to handle immutable DaemonSet selector change

### DIFF
--- a/cluster-apps/base/spegel/app/helmrelease.yaml
+++ b/cluster-apps/base/spegel/app/helmrelease.yaml
@@ -8,6 +8,9 @@ spec:
   chartRef:
     kind: OCIRepository
     name: spegel
+  upgrade:
+    # DaemonSet selector changed in 0.7.0; force allows delete+recreate of immutable fields.
+    force: true
   values:
     service:
       registry:


### PR DESCRIPTION
## Summary

- spegel 0.7.0 changed the DaemonSet's label selector
- Kubernetes label selectors are immutable, so `helm upgrade` fails trying to patch the existing DaemonSet
- Adding `upgrade.force: true` allows Helm to delete and recreate the DaemonSet instead

## Test plan

- [ ] `spegel` HelmRelease reconciles successfully after this change
- [ ] spegel DaemonSet is running on all nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)