### PR TITLE
feat(komga): add komga to default namespace on chongus

### DIFF
--- a/cluster-apps/chongus/default/komga/app/helmrelease.yaml
+++ b/cluster-apps/chongus/default/komga/app/helmrelease.yaml
@@ -1,0 +1,70 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: komga
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: komga
+  interval: 30m
+  values:
+    controllers:
+      komga:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/gotson/komga
+              tag: 1.24.4@sha256:dae630271561b642d47c9723803ec77900d1f0a803fbe6a42da69db5b21ebaeb
+            env:
+              SERVER_PORT: &port 8080
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /actuator/health
+                    port: *port
+              readiness: *probe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /actuator/health
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 15m
+                memory: 1Gi
+              limits:
+                memory: 4Gi
+    persistence:
+      config:
+        existingClaim: komga
+      media:
+        type: nfs
+        server: nas.rtrox.io
+        path: /mnt/rusty/media
+        globalMounts:
+          - path: /data
+    route:
+      app:
+        hostnames:
+          - komga.rtrox.io
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+    service:
+      app:
+        controller: komga
+        ports:
+          http:
+            port: *port

--- a/cluster-apps/chongus/default/komga/app/kustomization.yaml
+++ b/cluster-apps/chongus/default/komga/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/cluster-apps/chongus/default/komga/app/ocirepository.yaml
+++ b/cluster-apps/chongus/default/komga/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: komga
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/cluster-apps/chongus/default/komga/ks.yaml
+++ b/cluster-apps/chongus/default/komga/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app komga
+  namespace: flux-system
+spec:
+  targetNamespace: default
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  path: ./cluster-apps/chongus/default/komga/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_CLAIM: *app

--- a/cluster-apps/chongus/default/kustomization.yaml
+++ b/cluster-apps/chongus/default/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./echo-server/ks.yaml
   - ./imap-classifier/ks.yaml
   - ./jellyfin/ks.yaml
+  - ./komga/ks.yaml
   - ./minecraft-cpw/ks.yaml
   - ./minecraft-sf5/ks.yaml
   - ./minecraft-vanilla/ks.yaml


### PR DESCRIPTION
## Summary

- Adds [Komga](https://komga.org/) (comic/manga/book server) to the `default` namespace on chongus
- Based on [joryirving's reference implementation](https://github.com/joryirving/home-ops/tree/main/kubernetes/apps/base/media/komga), adapted to chongus patterns
- Image updated to latest: `ghcr.io/gotson/komga:1.24.4@sha256:dae630271561b642d47c9723803ec77900d1f0a803fbe6a42da69db5b21ebaeb`

**Key details:**
- Chart: `app-template` 4.6.2
- Accessible at `komga.rtrox.io` via `envoy-internal`
- Config PVC backed up via Volsync (10Gi)
- Media served from `nas.rtrox.io:/mnt/rusty/media` mounted at `/data`
- Health checks via Spring Boot Actuator (`/actuator/health`)

## Test plan

- [ ] `komga` Kustomization reconciles successfully
- [ ] `komga` HelmRelease deploys and pod becomes ready
- [ ] `komga.rtrox.io` is reachable and shows the Komga UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)