### PR TITLE
feat(cluster): add mini cluster (3x Minisforum MS-A2)

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -22,3 +22,7 @@ cluster/chongus:
       - any-glob-to-any-file: "cluster-apps/chongus/**/*"
       - any-glob-to-any-file: "cluster-cd/chongus/*"
       - any-glob-to-any-file: "clusters/chongus/*"
+cluster/mini:
+  - changed-files:
+      - any-glob-to-any-file: "cluster-apps/mini/**/*"
+      - any-glob-to-any-file: "clusters/mini/*"

--- a/.github/renovate/clusters.json5
+++ b/.github/renovate/clusters.json5
@@ -11,5 +11,10 @@
       matchFileNames: ["**/cluster-cd/aps/chongus/**", "**/cluster-apps/chongus/**", "**/clusters/chongus/**"],
       additionalBranchPrefix: "chongus-",
     },
+    {
+      description: "Separate PRs for mini cluster",
+      matchFileNames: ["**/cluster-apps/mini/**", "**/clusters/mini/**"],
+      additionalBranchPrefix: "mini-",
+    },
   ],
 }

--- a/.github/workflows/flux-local-mini.yaml
+++ b/.github/workflows/flux-local-mini.yaml
@@ -1,0 +1,137 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Flux Local
+
+on:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  filter-changes:
+    name: Filter changes
+    runs-on: ubuntu-latest
+    outputs:
+      changed-files: ${{ steps.changed-files.outputs.changed_files }}
+    steps:
+      - name: Get changed files
+        id: changed-files
+        uses: bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0
+        with:
+          patterns: |-
+            cluster-apps/base/**/*
+            cluster-apps/mini/**/*
+            clusters/base/**/*
+            clusters/mini/**/*
+
+  test:
+    if: ${{ needs.filter-changes.outputs.changed-files != '[]' }}
+    name: Flux Local Test
+    runs-on: ubuntu-latest
+    needs:
+      - filter-changes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run flux-local test
+        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
+        with:
+          args: test --enable-helm --all-namespaces --path /github/workspace/clusters/mini/flux/cluster -v
+
+  diff:
+    if: ${{ needs.filter-changes.outputs.changed-files != '[]' }}
+    name: Flux Local Diff
+    runs-on: ubuntu-latest
+    needs:
+      - filter-changes
+    permissions:
+      contents: read
+      pull-requests: write
+    strategy:
+      matrix:
+        resources:
+          - helmrelease
+          - kustomization
+      max-parallel: 4
+      fail-fast: false
+    steps:
+      - name: Checkout Pull Request Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: pull
+          persist-credentials: false
+
+      - name: Checkout Default Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: "${{ github.event.repository.default_branch }}"
+          path: default
+          persist-credentials: false
+
+      - name: Run flux-local diff
+        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
+        with:
+          args: >-
+            diff ${{ matrix.resources }}
+            --unified 6
+            --path /github/workspace/pull/clusters/mini/flux/cluster
+            --path-orig /github/workspace/default/clusters/mini/flux/cluster
+            --strip-attrs "helm.sh/chart,checksum/config,app.kubernetes.io/version,chart"
+            --limit-bytes 10000
+            --all-namespaces
+            --output-file diff.patch
+
+      - name: Generate Diff
+        id: diff
+        run: |
+          {
+              echo 'diff<<EOF'
+              cat diff.patch
+              echo EOF
+          } >> "${GITHUB_OUTPUT}";
+          {
+              echo "## Flux ${{ matrix.resources }} diff"
+              echo '```diff'
+              cat diff.patch
+              echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Generate Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.diff != '' }}
+        id: app-token
+        with:
+          app-id: ${{ vars.HOMELAB_APP_ID }}
+          private-key: ${{ secrets.HOMELAB_APP_KEY }}
+
+      - if: ${{ steps.diff.outputs.diff != '' }}
+        name: Add Comment
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          header: ${{ github.event.pull_request.number }}/kubernetes/${{ matrix.resources }}
+          message: |
+            ```diff
+            ${{ steps.diff.outputs.diff }}
+            ```
+
+  flux-local-success:
+    needs:
+      - test
+      - diff
+    if: ${{ !cancelled() }}
+    name: Flux Local successful
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job status
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -26,3 +26,12 @@ jobs:
     secrets: inherit
     needs:
       - simple-checks
+
+  flux-local-mini:
+    uses: rtrox/home-ops/.github/workflows/flux-local-mini.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets: inherit
+    needs:
+      - simple-checks

--- a/.taskfiles/flux/Taskfile.yaml
+++ b/.taskfiles/flux/Taskfile.yaml
@@ -14,7 +14,7 @@ tasks:
       vars:
         - &requires-cluster-name
           name: CLUSTER_NAME
-          enum: [chongus, bitty]
+          enum: [chongus, bitty, mini]
 
   test:
     desc: Validate all Flux resources with flux-local

--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -9,7 +9,7 @@ tasks:
       vars:
         - &requires-cluster-name
           name: CLUSTER_NAME
-          enum: [chongus, bitty]
+          enum: [chongus, bitty, mini]
 
   generate-clusterconfig:
     desc: Generate clusterconfig for Talos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This repository implements a GitOps-managed Kubernetes infrastructure using FluxCD, running two clusters: Chongus (primary, modern pattern) and Bitty (secondary, being phased out). The infrastructure is built on Talos Linux with a focus on automation, high availability, and disaster recovery.
+This repository implements a GitOps-managed Kubernetes infrastructure using FluxCD, running three clusters: Chongus (primary, modern pattern), Mini (secondary, AMD/NVIDIA), and Bitty (tertiary, being phased out). The infrastructure is built on Talos Linux with a focus on automation, high availability, and disaster recovery.
 
 ## Key Principles
 
@@ -68,20 +68,33 @@ This repository implements a GitOps-managed Kubernetes infrastructure using Flux
 - Cilium CNI with Gateway API
 - External-DNS (Cloudflare)
 
-### Bitty Cluster (Secondary - Being Phased Out)
+### Mini Cluster (Secondary - Follow Chongus Pattern)
+
+**Summary:** 3x Minisforum MS-A2 nodes (AMD Ryzen AI 9), all with NVIDIA GPUs.
+
+- Kubernetes v1.36.0 on Talos v1.13.0
+- Node IPs: 172.30.31.1-3
+- Load Balancer Pool: 172.22.32.0/24
+  - 172.22.32.1: envoy-internal (default, local network)
+  - 172.22.32.2: envoy-external (internet via Cloudflare)
+- Talos extensions: `amd-ucode`, `iscsi-tools`, `nonfree-kmod-nvidia-production`, `nvidia-container-toolkit-production`
+- Storage: Rook-Ceph (3x replication), OpenEBS for volsync cache
+- Cilium cluster ID: 3
+
+### Bitty Cluster (Tertiary - Being Phased Out)
 
 **Summary:** 3x Intel NUC nodes with QuickSync iGPU, secondary cluster for smaller workloads.
 
 - Kubernetes v1.33.0 on Talos v1.10.1
 - IP Range: 172.30.21.1-3
 - Use for: QuickSync video transcoding only
-- **Do not deploy new applications to Bitty** - migrate to Chongus
+- **Do not deploy new applications to Bitty** - migrate to Chongus or Mini
 
 ## Repository Structure
 
 ### Understanding Namespace Directories
 
-Directories immediately under `cluster-apps/chongus/` or `cluster-apps/bitty/` are **Kubernetes namespace directories**, NOT application directories. Each namespace directory:
+Directories immediately under `cluster-apps/chongus/`, `cluster-apps/mini/`, or `cluster-apps/bitty/` are **Kubernetes namespace directories**, NOT application directories. Each namespace directory:
 
 - Represents a single Kubernetes namespace
 - Contains a `kustomization.yaml` that includes namespace components and lists all apps

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ This repository contains the Infrastructure as Code (IaC) for my home Kubernetes
 
 ### Clusters
 
-I run two Kubernetes clusters:
+I run three Kubernetes clusters:
 
 - **Chongus** (Primary) - Dell R730 servers with NVIDIA GPUs
-- **Bitty** (Secondary) - Intel NUC cluster
+- **Mini** (Secondary) - Minisforum MS-A2 nodes (AMD Ryzen AI 9) with NVIDIA GPUs
+- **Bitty** (Tertiary, being phased out) - Intel NUC cluster
 
 ### Core Components
 
@@ -63,16 +64,21 @@ This repository follows a structured GitOps layout:
 ```text
 📁 cluster-apps/           # Application definitions (Flux source)
 ├── 📁 base/              # Shared applications across clusters
-├── 📁 chongus/           # Chongus cluster applications (NEW PATTERN)
+├── 📁 chongus/           # Chongus cluster applications (primary)
 │   └── 📁 [namespace]/
 │       └── 📁 [app]/
 │           ├── 📁 app/   # HelmRelease + configs
 │           └── ks.yaml   # Flux Kustomization
+├── 📁 mini/              # Mini cluster applications (secondary)
 ├── 📁 bitty/             # Bitty cluster (deprecated pattern)
 └── 📁 components/        # Reusable Kustomize components
 
 📁 clusters/              # Cluster bootstrap configurations
 ├── 📁 chongus/
+│   ├── 📁 bootstrap/     # Helmfile-based bootstrap
+│   ├── 📁 flux/          # Flux Kustomizations
+│   └── 📁 talos/         # Talos configuration
+├── 📁 mini/
 │   ├── 📁 bootstrap/     # Helmfile-based bootstrap
 │   ├── 📁 flux/          # Flux Kustomizations
 │   └── 📁 talos/         # Talos configuration
@@ -135,21 +141,26 @@ While most infrastructure runs on-premises, some cloud services are used:
 | ------------ | ---------- | ------ | ---------------------- | --------------------------------- |
 | Dell R730 x3 | Intel Xeon | 256GB+ | 2x Samsung 870 EVO 2TB | Kubernetes nodes with NVIDIA GPUs |
 
-**Storage:**
+- Rook-Ceph: 6x 2TB SSDs (2 per node), `ceph-block` storage class, 3x replication
+- LB pool: 172.22.12.0/24
 
-- Rook-Ceph: 6x 2TB SSDs (2 per node)
-- Storage Class: `ceph-block` (default)
-- Replication: 3 replicas
+### Mini Cluster (Secondary)
 
-### Bitty Cluster (Secondary)
+| Device              | CPU               | RAM   | Storage | Purpose                           |
+| ------------------- | ----------------- | ----- | ------- | --------------------------------- |
+| Minisforum MS-A2 x3 | AMD Ryzen AI 9 HX | 96GB+ | 2x NVMe | Kubernetes nodes with NVIDIA GPUs |
 
-| Device       | CPU         | RAM   | Storage | Purpose                        |
-| ------------ | ----------- | ----- | ------- | ------------------------------ |
+- Rook-Ceph: 3x NVMe (1 per node), `ceph-block` storage class, 3x replication
+- LB pool: 172.22.32.0/24
+
+### Bitty Cluster (Tertiary - Being Phased Out)
+
+| Device       | CPU         | RAM   | Storage | Purpose                         |
+| ------------ | ----------- | ----- | ------- | ------------------------------- |
 | Intel NUC x3 | Intel i5/i7 | 32GB+ | NVMe    | Kubernetes nodes with QuickSync |
 
-- Rook-Ceph: 3x 512GB SSDs (1 per node)
-- Storage Class: `ceph-block` (default)
-- Replication: 3 replicas
+- Rook-Ceph: 3x 512GB SSDs (1 per node), `ceph-block` storage class, 3x replication
+- LB pool: 172.22.22.0/24
 
 ### Supporting Infrastructure
 

--- a/cluster-apps/mini/flux-system/flux-operator/app/helmrelease.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/app/helmrelease.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flux-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: flux-operator
+  interval: 30m
+  valuesFrom:
+    - kind: ConfigMap
+      name: flux-operator-helm-values

--- a/cluster-apps/mini/flux-system/flux-operator/app/kustomization.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/app/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: flux-system
+
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: flux-operator-helm-values
+    files:
+      - values.yaml=./values.yaml
+configurations:
+  - kustomizeconfig.yaml

--- a/cluster-apps/mini/flux-system/flux-operator/app/kustomizeconfig.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/app/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/cluster-apps/mini/flux-system/flux-operator/app/ocirepository.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.48.0
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator

--- a/cluster-apps/mini/flux-system/flux-operator/app/values.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/app/values.yaml
@@ -1,0 +1,3 @@
+---
+serviceMonitor:
+  create: true

--- a/cluster-apps/mini/flux-system/flux-operator/instance/helmrelease.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/instance/helmrelease.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flux-instance
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: flux-instance
+  interval: 30m
+  valuesFrom:
+    - kind: ConfigMap
+      name: flux-instance-helm-values

--- a/cluster-apps/mini/flux-system/flux-operator/instance/kustomization.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/instance/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: flux-system
+
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./prometheusrule.yaml
+  - ./podmonitor.yaml
+configMapGenerator:
+  - name: flux-instance-helm-values
+    files:
+      - values.yaml=./values.yaml
+configurations:
+  - kustomizeconfig.yaml

--- a/cluster-apps/mini/flux-system/flux-operator/instance/kustomizeconfig.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/instance/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/cluster-apps/mini/flux-system/flux-operator/instance/ocirepository.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/instance/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-instance
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.48.0
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance

--- a/cluster-apps/mini/flux-system/flux-operator/instance/podmonitor.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/instance/podmonitor.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flux-system
+  labels:
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/component: monitoring
+spec:
+  namespaceSelector:
+    matchNames:
+      - flux-system
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - helm-controller
+          - source-controller
+          - kustomize-controller
+          - notification-controller
+          - image-automation-controller
+          - image-reflector-controller
+  podMetricsEndpoints:
+    - port: http-prom

--- a/cluster-apps/mini/flux-system/flux-operator/instance/prometheusrule.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/instance/prometheusrule.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: flux-instance-rules
+spec:
+  groups:
+    - name: flux-instance.rules
+      rules:
+        - alert: FluxInstanceAbsent
+          expr: absent(flux_instance_info{exported_namespace="flux-system", name="flux"})
+          for: 15m
+          annotations:
+            summary: Flux instance metric is missing
+            description: |
+              The flux_instance_info metric for the Flux instance in namespace {{ $labels.exported_namespace }} is not available.
+          labels:
+            severity: critical
+        - alert: FluxInstanceNotReady
+          expr: flux_instance_info{exported_namespace="flux-system", name="flux", ready!="True"}
+          for: 15m
+          annotations:
+            summary: Flux instance {{ $labels.name }} is not ready
+            description: |
+              The Flux instance in namespace {{ $labels.exported_namespace }} is not ready.
+              Reason: {{ $labels.reason }}
+          labels:
+            severity: critical

--- a/cluster-apps/mini/flux-system/flux-operator/instance/values.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/instance/values.yaml
@@ -1,0 +1,101 @@
+---
+instance:
+  distribution:
+    # renovate: depName=controlplaneio-fluxcd/distribution datasource=github-releases
+    version: 2.8.6
+  cluster:
+    networkPolicy: false
+  components:
+    - source-controller
+    - kustomize-controller
+    - helm-controller
+    - notification-controller
+  sync:
+    kind: GitRepository
+    url: https://github.com/rtrox/home-ops.git
+    ref: refs/heads/main
+    path: clusters/mini/flux
+    interval: 1h
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: flux
+  kustomize:
+    patches:
+      # Increase the number of workers
+      - patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --concurrent=10
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --requeue-dependency=5s
+        target:
+          kind: Deployment
+          name: (kustomize-controller|helm-controller|source-controller)
+      # Increase the memory limits
+      - patch: |
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: all
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: manager
+                    resources:
+                      limits:
+                        memory: 2Gi
+        target:
+          kind: Deployment
+          name: (kustomize-controller|helm-controller|source-controller)
+      # Enable in-memory kustomize builds
+      - patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --concurrent=20
+          - op: replace
+            path: /spec/template/spec/volumes/0
+            value:
+              name: temp
+              emptyDir:
+                medium: Memory
+        target:
+          kind: Deployment
+          name: kustomize-controller
+      # Enable Helm repositories caching
+      - patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --helm-cache-max-size=10
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --helm-cache-ttl=60m
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --helm-cache-purge-interval=5m
+        target:
+          kind: Deployment
+          name: source-controller
+      # Flux near OOM detection for Helm
+      - patch: |
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --feature-gates=OOMWatch=true
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --oom-watch-memory-threshold=95
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --oom-watch-interval=500ms
+        target:
+          kind: Deployment
+          name: helm-controller
+      - # Disable chart digest tracking
+        patch: |-
+          - op: add
+            path: /spec/template/spec/containers/0/args/-
+            value: --feature-gates=DisableChartDigestTracking=true
+        target:
+          kind: Deployment
+          name: helm-controller

--- a/cluster-apps/mini/flux-system/flux-operator/ks.yaml
+++ b/cluster-apps/mini/flux-system/flux-operator/ks.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname flux-operator
+  namespace: &namespace flux-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 30m
+  timeout: 5m
+  path: ./cluster-apps/mini/flux-system/flux-operator/app
+  prune: false # Never delete this
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname flux-instance
+  namespace: &namespace flux-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 30m
+  timeout: 5m
+  path: ./cluster-apps/mini/flux-system/flux-operator//instance
+  prune: false # Never delete this
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/cluster-apps/mini/kube-system/cilium/app/crds.yaml
+++ b/cluster-apps/mini/kube-system/cilium/app/crds.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/gitrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: gateway-api-crd
+spec:
+  interval: 30m
+  url: https://github.com/kubernetes-sigs/gateway-api
+  ref:
+    # renovate: depName=kubernetes-sigs/gateway-api datasource=github-releases
+    tag: v1.5.1
+  ignore: |
+    # exclude
+    /*
+    # include
+    !config/crd/experimental
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gateway-api
+spec:
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: gateway-api-crd
+  wait: true
+  interval: 15m
+  retryInterval: 1m
+  timeout: 5m

--- a/cluster-apps/mini/kube-system/cilium/app/helmrelease.yaml
+++ b/cluster-apps/mini/kube-system/cilium/app/helmrelease.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2beta2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cilium
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: cilium
+  interval: 30m
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: cilium-values
+
+  values:
+    hubble:
+      relay:
+        enabled: true
+        rollOutPods: true
+        prometheus:
+          serviceMonitor:
+            enabled: true
+
+      ui:
+        enabled: true
+        rollOutPods: true

--- a/cluster-apps/mini/kube-system/cilium/app/kustomization.yaml
+++ b/cluster-apps/mini/kube-system/cilium/app/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./crds.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+
+configMapGenerator:
+  - name: cilium-values
+    files:
+      - values.yaml=./values.yaml
+
+configurations:
+  - kustomizeconfig.yaml

--- a/cluster-apps/mini/kube-system/cilium/app/kustomizeconfig.yaml
+++ b/cluster-apps/mini/kube-system/cilium/app/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/cluster-apps/mini/kube-system/cilium/app/ocirepository.yaml
+++ b/cluster-apps/mini/kube-system/cilium/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cilium
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://ghcr.io/home-operations/charts-mirror/cilium
+  ref:
+    tag: 1.18.6

--- a/cluster-apps/mini/kube-system/cilium/app/values.yaml
+++ b/cluster-apps/mini/kube-system/cilium/app/values.yaml
@@ -1,0 +1,100 @@
+---
+cluster:
+  name: mini
+  id: 3
+
+k8sServiceHost: localhost
+k8sServicePort: 7445
+
+rollOutCiliumPods: true
+localRedirectPolicy: true
+
+kubeProxyReplacement: true
+kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
+
+enableRuntimeDeviceDetection: true
+devices: eth+
+
+loadBalancer:
+  algorithm: maglev
+  mode: dsr
+
+bandwidthManager:
+  enabled: true
+  bbr: true
+bpf:
+  masquerade: true
+  tproxy: true
+
+ipam:
+  mode: kubernetes
+
+operator:
+  dashboards:
+    enabled: true
+    annotations:
+      grafana_folder: Cilium
+  prometheus:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+  replicas: 2
+  rollOutPods: true
+
+enableIPv4BIGTCP: true
+autoDirectNodeRoutes: true
+ipv4NativeRoutingCIDR: 10.244.0.0/16
+routingMode: native
+
+hubble:
+  enabled: true
+  serviceMonitor:
+    enabled: false
+
+  relay:
+    enabled: true
+    rollOutPods: true
+
+  ui:
+    enabled: true
+    ingress:
+      enabled: false
+    rollOutPods: true
+
+envoy:
+  enabled: false
+endpointRoutes:
+  enabled: true
+gatewayAPI:
+  enabled: true
+  enableAlpn: true
+  xffNumTrustedHops: 1
+
+securityContext:
+  capabilities:
+    ciliumAgent:
+      - CHOWN
+      - KILL
+      - NET_ADMIN
+      - NET_RAW
+      - IPC_LOCK
+      - SYS_ADMIN
+      - SYS_RESOURCE
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    cleanCiliumState:
+      - NET_ADMIN
+      - SYS_ADMIN
+      - SYS_RESOURCE
+
+cgroup:
+  autoMount:
+    enabled: false
+  hostRoot: /sys/fs/cgroup
+
+prometheus:
+  serviceMonitor:
+    trustCRDsExist: true
+    enabled: true

--- a/cluster-apps/mini/kube-system/cilium/config/kustomization.yaml
+++ b/cluster-apps/mini/kube-system/cilium/config/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./lbipam.yaml

--- a/cluster-apps/mini/kube-system/cilium/config/lbipam.yaml
+++ b/cluster-apps/mini/kube-system/cilium/config/lbipam.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: main-pool
+spec:
+  allowFirstLastIPs: "No"
+  blocks:
+    - cidr: 172.22.32.0/24

--- a/cluster-apps/mini/kube-system/cilium/ks.yaml
+++ b/cluster-apps/mini/kube-system/cilium/ks.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+# Note: this kustomization does not leverage overlays for a reason!
+# Cilium changes should be delivered to each cluster separately for safety.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname cilium
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 30m
+  timeout: 5m
+  path: ./cluster-apps/mini/kube-system/cilium/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+# Note: this kustomization does not leverage overlays for a reason!
+# Cilium changes should be delivered to each cluster separately for safety.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cilium-config
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: cilium
+      app.kubernetes.io/component: config
+  interval: 30m
+  timeout: 5m
+  path: ./cluster-apps/mini/kube-system/cilium/config
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/cluster-apps/mini/kube-system/coredns/app/helmrelease.yaml
+++ b/cluster-apps/mini/kube-system/coredns/app/helmrelease.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: coredns
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: coredns
+  interval: 30m
+
+  valuesFrom:
+    - kind: ConfigMap
+      name: coredns-values

--- a/cluster-apps/mini/kube-system/coredns/app/kustomization.yaml
+++ b/cluster-apps/mini/kube-system/coredns/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+
+configMapGenerator:
+  - name: coredns-values
+    files:
+      - values.yaml=./values.yaml
+
+configurations:
+  - kustomizeconfig.yaml

--- a/cluster-apps/mini/kube-system/coredns/app/kustomizeconfig.yaml
+++ b/cluster-apps/mini/kube-system/coredns/app/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/cluster-apps/mini/kube-system/coredns/app/ocirepository.yaml
+++ b/cluster-apps/mini/kube-system/coredns/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: coredns
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://ghcr.io/coredns/charts/coredns
+  ref:
+    tag: 1.45.2

--- a/cluster-apps/mini/kube-system/coredns/app/values.yaml
+++ b/cluster-apps/mini/kube-system/coredns/app/values.yaml
@@ -1,0 +1,58 @@
+---
+fullnameOverride: coredns
+replicaCount: 3
+k8sAppLabelOverride: kube-dns
+serviceAccount:
+  create: true
+service:
+  name: kube-dns
+  clusterIP: 10.96.0.10
+servers:
+  - zones:
+      - zone: .
+        scheme: dns://
+        use_tcp: true
+    port: 53
+    plugins:
+      - name: errors
+      - name: health
+        configBlock: |-
+          lameduck 5s
+      - name: ready
+      - name: log
+        configBlock: |-
+          class error
+      - name: prometheus
+        parameters: 0.0.0.0:9153
+      - name: kubernetes
+        parameters: cluster.local in-addr.arpa ip6.arpa
+        configBlock: |-
+          pods insecure
+          fallthrough in-addr.arpa ip6.arpa
+      - name: forward
+        parameters: . /etc/resolv.conf
+      - name: cache
+        parameters: 30
+      - name: loop
+      - name: reload
+      - name: loadbalance
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/instance: coredns

--- a/cluster-apps/mini/kube-system/coredns/ks.yaml
+++ b/cluster-apps/mini/kube-system/coredns/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+# Note: this kustomization does not leverage overlays for a reason!
+# Cilium changes should be delivered to each cluster separately for safety.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname coredns
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 10m
+  path: ./cluster-apps/mini/kube-system/coredns/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/cluster-apps/mini/kube-system/kustomization.yaml
+++ b/cluster-apps/mini/kube-system/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cilium/ks.yaml
+  - ./coredns/ks.yaml
+  - ./metrics-server/ks.yaml

--- a/cluster-apps/mini/kube-system/metrics-server/ks.yaml
+++ b/cluster-apps/mini/kube-system/metrics-server/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+# Note: this kustomization does not leverage overlays for a reason!
+# Cilium changes should be delivered to each cluster separately for safety.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname metrics-server
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 10m
+  path: ./cluster-apps/base/metrics-server/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/clusters/mini/bootstrap/helmfile.d/00-crds.yaml
+++ b/clusters/mini/bootstrap/helmfile.d/00-crds.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/helmfile
+helmDefaults:
+  cleanupOnFail: true
+  wait: true
+  waitForJobs: true
+  args:
+    - --include-crds
+    - --no-hooks
+  postRenderer: bash
+  postRendererArgs:
+    - -c
+    - yq ea --exit-status 'select(.kind == "CustomResourceDefinition")' -
+
+releases:
+  - name: external-dns
+    namespace: network
+    chart: oci://ghcr.io/home-operations/charts-mirror/external-dns
+    version: 1.21.1
+
+  - name: gateway-api-crds
+    namespace: kube-system
+    chart: oci://ghcr.io/wiremind/wiremind-helm-charts/gateway-api-crds
+    version: 1.5.1
+
+  - name: keda
+    namespace: kube-system
+    chart: oci://ghcr.io/home-operations/charts-mirror/keda
+    version: 2.19.0
+
+  - name: kube-prometheus-stack
+    namespace: observability
+    chart: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
+    version: 82.18.0
+
+  - name: external-secrets
+    namespace: external-secrets
+    chart: oci://ghcr.io/external-secrets/charts/external-secrets
+    version: 2.4.1

--- a/clusters/mini/bootstrap/helmfile.d/01-apps.yaml
+++ b/clusters/mini/bootstrap/helmfile.d/01-apps.yaml
@@ -1,0 +1,64 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/helmfile
+helmDefaults:
+  cleanupOnFail: true
+  wait: true
+  waitForJobs: true
+
+releases:
+  - name: cilium
+    namespace: kube-system
+    chart: oci://ghcr.io/home-operations/charts-mirror/cilium
+    version: 1.18.6
+    values:
+      - "../../../../cluster-apps/mini/kube-system/cilium/app/values.yaml"
+    hooks:
+      # Apply cilium network configuration
+      - events:
+          - postsync
+        command: kubectl
+        args:
+          - apply
+          - --namespace=kube-system
+          - --server-side
+          - --field-manager=kustomize-controller
+          - --kustomize
+          - ../../../../cluster-apps/mini/kube-system/cilium/config/
+        showlogs: true
+
+  - name: coredns
+    namespace: kube-system
+    chart: oci://ghcr.io/coredns/charts/coredns
+    version: 1.45.2
+    values:
+      - "../../../../cluster-apps/mini/kube-system/coredns/app/values.yaml"
+    needs:
+      - kube-system/cilium
+
+  - name: cert-manager
+    namespace: cert-manager
+    chart: oci://quay.io/jetstack/charts/cert-manager
+    version: v1.20.2
+    values:
+      - "../../../../cluster-apps/base/cert-manager/app/values.yaml"
+    needs:
+      - kube-system/coredns
+
+  - name: flux-operator
+    namespace: flux-system
+    chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
+    version: 0.48.0
+    values:
+      - "../../../../cluster-apps/mini/flux-system/flux-operator/app/values.yaml"
+    needs:
+      - cert-manager/cert-manager
+
+  - name: flux-instance
+    namespace: flux-system
+    chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
+    version: 0.48.0
+    wait: false
+    values:
+      - "../../../../cluster-apps/mini/flux-system/flux-operator/instance/values.yaml"
+    needs:
+      - flux-system/flux-operator

--- a/clusters/mini/bootstrap/resources/namespaces.yaml
+++ b/clusters/mini/bootstrap/resources/namespaces.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system

--- a/clusters/mini/flux/cluster/cluster.yaml
+++ b/clusters/mini/flux/cluster/cluster.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-repositories
+  namespace: flux-system
+spec:
+  targetNamespace: flux-system
+  interval: 30m
+  path: ./clusters/base/flux/repositories
+  prune: true
+  wait: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./cluster-apps/mini
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: flux-repositories

--- a/clusters/mini/talos/talconfig.yaml
+++ b/clusters/mini/talos/talconfig.yaml
@@ -1,0 +1,219 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json
+clusterName: ${clusterName}
+endpoint: https://${clusterName}.${clusterDNSSuffix}:6443
+allowSchedulingOnMasters: true
+# renovate: depName=ghcr.io/siderolabs/installer datasource=docker extractVersion=^(?<version>.*)$
+talosVersion: v1.13.0
+# renovate: depName=kubernetes/kubernetes datasource=github-releases extractVersion=^v(?<version>.*)$
+kubernetesVersion: 1.36.0
+
+additionalApiServerCertSans: &sans
+  - ${clusterName}.${clusterDNSSuffix}
+  - 127.0.0.1 # KubePrism
+additionalMachineCertSans: *sans
+
+cniConfig:
+  name: none
+
+clusterPodNets:
+  - 10.244.0.0/16
+  # - ${ipv6PodNet}
+clusterSvcNets:
+  - 10.96.0.0/12
+  # - ${ipv6SvcNet}
+
+nodes:
+  - hostname: node01.${clusterName}.${clusterDNSSuffix}
+    ipAddress: 172.30.31.1
+    controlPlane: true
+    installDiskSelector:
+      size: < 500GB
+    machineSpec:
+      mode: metal
+      arch: amd64
+
+  - hostname: node02.${clusterName}.${clusterDNSSuffix}
+    ipAddress: 172.30.31.2
+    controlPlane: true
+    installDiskSelector:
+      size: < 500GB
+    machineSpec:
+      mode: metal
+      arch: amd64
+
+  - hostname: node03.${clusterName}.${clusterDNSSuffix}
+    ipAddress: 172.30.31.3
+    controlPlane: true
+    installDiskSelector:
+      size: < 500GB
+    machineSpec:
+      mode: metal
+      arch: amd64
+
+controlPlane:
+  nodeLabels:
+    topology.kubernetes.io/region: ${clusterName}
+    topology.kubernetes.io/zone: "1"
+
+  schematic:
+    customization:
+      extraKernelArgs:
+        - apparmor=0
+        - net.ifnames=0
+        - amd_iommu=on # PCI Passthrough
+      systemExtensions:
+        officialExtensions:
+          - siderolabs/amd-ucode
+          - siderolabs/iscsi-tools
+          - siderolabs/nonfree-kmod-nvidia-production
+          - siderolabs/nvidia-container-toolkit-production
+
+  patches:
+    # Configure containerd
+    - |-
+      machine:
+        files:
+          - op: create
+            path: /etc/cri/conf.d/20-customization.part
+            content: |
+              [plugins]
+                [plugins."io.containerd.grpc.v1.cri"]
+                  enable_unprivileged_ports = true
+                  enable_unprivileged_icmp = true
+              [plugins."io.containerd.grpc.v1.cri".containerd]
+                discard_unpacked_layers = false
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+                discard_unpacked_layers = false
+
+    # Disable search domain everywhere
+    - |-
+      machine:
+        network:
+          disableSearchDomain: true
+
+    # Enable HostDNS
+    - |-
+      machine:
+        features:
+          hostDNS:
+            enabled: true
+            resolveMemberNames: true
+            forwardKubeDNSToHost: false
+
+    # Enable KubePrism
+    - |-
+      machine:
+        features:
+          kubePrism:
+            enabled: true
+            port: 7445
+
+    # Kubelet configuration
+    - |-
+      machine:
+        kubelet:
+          extraArgs:
+            rotate-server-certificates: "true"
+          extraConfig:
+            maxPods: 150
+          nodeIP:
+            validSubnets:
+              - 172.16.0.0/12
+
+    # Enable MutatingAdmissionPolicy
+    - |-
+      cluster:
+        apiServer:
+          extraArgs:
+            runtime-config: admissionregistration.k8s.io/v1alpha1=true
+            feature-gates: MutatingAdmissionPolicy=true
+
+    # Cluster configuration
+    - |-
+      cluster:
+        allowSchedulingOnControlPlanes: true
+        proxy:
+          disabled: true
+        coreDNS:
+          disabled: true
+        scheduler:
+          config:
+            apiVersion: kubescheduler.config.k8s.io/v1
+            kind: KubeSchedulerConfiguration
+            profiles:
+              - schedulerName: default-scheduler
+                pluginConfig:
+                  - name: PodTopologySpread
+                    args:
+                      defaultingType: List
+                      defaultConstraints:
+                        - maxSkew: 1
+                          topologyKey: kubernetes.io/hostname
+                          whenUnsatisfiable: ScheduleAnyway
+
+    - |-
+      machine:
+        network:
+          interfaces:
+            - deviceSelector:
+                busPath: "0*"
+              dhcp: true
+
+    # NFS Mount Configuration
+    - |-
+      machine:
+        files:
+          - op: overwrite
+            path: /etc/nfsmount.conf
+            permissions: 0o644
+            content: |
+              [ NFSMount_Global_Options ]
+              nfsvers=4.2
+              hard=True
+              noatime=True
+              nconnect=15
+
+    # Custom sysctls
+    - |-
+      machine:
+        sysctls:
+          fs.inotify.max_user_watches: "1048576"
+          fs.inotify.max_user_instances: "8192"
+          net.core.bpf_jit_harden: 1
+          net.core.rmem_max: 67108864            # Cloudflared / QUIC
+          net.core.wmem_max: 67108864            # Cloudflared / QUIC
+
+    # Add Kernel Modules
+    - |-
+      machine:
+        kernel:
+          modules:
+            - name: "nvidia"
+            - name: "nvidia_uvm"
+            - name: "nvidia_drm"
+            - name: "nvidia_modeset"
+
+    # Enable K8s Talos API Access
+    - |-
+      machine:
+        features:
+          kubernetesTalosAPIAccess:
+            enabled: true
+            allowedRoles:
+              - os:admin
+            allowedKubernetesNamespaces:
+              - actions-runner-system
+              - system-upgrade
+
+worker:
+  schematic:
+    customization:
+      extraKernelArgs:
+        - net.ifnames=0
+      systemExtensions:
+        officialExtensions:
+          - siderolabs/amd-ucode
+          - siderolabs/iscsi-tools
+          - siderolabs/nonfree-kmod-nvidia-production
+          - siderolabs/nvidia-container-toolkit-production


### PR DESCRIPTION
## Summary

- Adds a new third Kubernetes cluster **mini** running on 3x Minisforum MS-A2 nodes (AMD Ryzen AI 9, all with NVIDIA GPUs), following the Chongus modern GitOps pattern
- Creates all infrastructure scaffolding: Talos config, helmfile bootstrap, Flux entry point, and initial `kube-system`/`flux-system` app manifests
- Updates CI/CD, Renovate, labeler, and Taskfile tooling to include `mini` alongside `chongus` and `bitty`

**Cluster parameters:**
- Node IPs: `172.30.31.1-3`
- LB pool: `172.22.32.0/24` (Cilium cluster ID 3)
- Talos extensions: `amd-ucode`, `iscsi-tools`, `nonfree-kmod-nvidia-production`, `nvidia-container-toolkit-production` (all nodes)
- Storage: Rook-Ceph (to be wired up incrementally)

## Test plan

- [x] `task flux:test-quick CLUSTER_NAME=mini` — 9 kustomizations passed
- [x] `task flux:test-quick CLUSTER_NAME=chongus` — 72 kustomizations passed (no regression)
- [x] All pre-commit hooks passed
- [ ] After merging: generate secrets (`talhelper gensecret`), create `talenv.sops.yaml`, run `task talos:generate-clusterconfig CLUSTER_NAME=mini`

🤖 Generated with [Claude Code](https://claude.com/claude-code)