### PR TITLE
fix(talos): fix upgrade-node task bugs, pin cluster versions, fix jellyfin volsync cache

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -73,7 +73,7 @@ tasks:
     preconditions:
       - which talosctl
       - which yq
-      - test -f "${TALOSCONFIG}"
+      - test -f "{{.TALOSCONFIG}}"
       - talosctl --nodes {{.NODE}} get machineconfig
     requires:
       vars:
@@ -83,9 +83,9 @@ tasks:
       FILE:
         sh: ls {{.TALOS_DIR}}/clusterconfig/{{.CLUSTER_NAME}}-{{.NODE}}*.yaml
       TALOS_IMAGE:
-        sh: yq '.machine.install.image' < "{{.FILE}}"
+        sh: yq 'select(.machine.install.image != null) | .machine.install.image' < "{{.FILE}}" | head -1
     cmds:
-      - talosctl --nodes {{.NODE}} upgrade --image="{{.TALOS_IMAGE}}" --timeout=10m
+      - talosctl --nodes {{.NODE}} upgrade --image="{{.TALOS_IMAGE}}" --timeout=10m {{ if eq "true" .FORCE }}--force{{ end }}
       - talosctl --nodes {{.NODE}} health
 
   _apply-machineconfig:

--- a/cluster-apps/chongus/default/jellyfin/ks.yaml
+++ b/cluster-apps/chongus/default/jellyfin/ks.yaml
@@ -22,6 +22,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 50Gi
+      VOLSYNC_CACHE_SNAPSHOTCLASS: ceph-block
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/clusters/chongus/talos/talconfig.yaml
+++ b/clusters/chongus/talos/talconfig.yaml
@@ -4,9 +4,9 @@ clusterName: ${clusterName}
 endpoint: https://${clusterName}.${clusterDNSSuffix}:6443
 allowSchedulingOnMasters: true
 # renovate: depName=ghcr.io/siderolabs/installer datasource=docker extractVersion=^(?<version>.*)$
-talosVersion: v1.13.5
+talosVersion: v1.12.2
 # renovate: depName=kubernetes/kubernetes datasource=github-releases extractVersion=^v(?<version>.*)$
-kubernetesVersion: 1.36.2
+kubernetesVersion: 1.33.1
 
 additionalApiServerCertSans: &sans
   - ${clusterName}.${clusterDNSSuffix}


### PR DESCRIPTION
## Summary

- Fix `TALOSCONFIG` shell variable reference (`${TALOSCONFIG}` → `{{.TALOSCONFIG}}`) in `upgrade-node` precondition
- Fix `yq` multi-document output appending `null` to installer image tag
- Add optional `FORCE=true` var to `upgrade-node` task (`--force` flag)
- Pin `talosVersion` to `v1.12.2` and `kubernetesVersion` to `1.33.1` in talconfig
- Switch jellyfin Volsync B2 cache to `ceph-block` to prevent node02 disk pressure (cache had grown to 180 GB on openebs-hostpath)

## Test plan

- [x] `task talos:upgrade-node NODE=node02 CLUSTER_NAME=chongus` runs successfully
- [x] `task talos:upgrade-node NODE=node02 CLUSTER_NAME=chongus FORCE=true` skips etcd health check
- [ ] Jellyfin Volsync cache PVC recreated on `ceph-block` after deleting old one

🤖 Generated with [Claude Code](https://claude.com/claude-code)