### PR TITLE
fix(rook-ceph): downgrade to v1.19.6 and pin below v1.20

### DIFF
--- a/.github/renovate/allowedVersions.json5
+++ b/.github/renovate/allowedVersions.json5
@@ -6,5 +6,14 @@
       matchPackageNames: ["ghcr.io/linuxserver/calibre-web"],
       allowedVersions: "<1",
     },
+    {
+      description: "Hold Rook-Ceph at v1.19.x — v1.20 (Tentacle) is flaky; revisit after the bare-metal rebuild",
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "ghcr.io/rook/rook-ceph",
+        "ghcr.io/rook/rook-ceph-cluster",
+      ],
+      allowedVersions: "<=1.19.6",
+    },
   ],
 }

--- a/.github/renovate/allowedVersions.json5
+++ b/.github/renovate/allowedVersions.json5
@@ -8,7 +8,6 @@
     },
     {
       description: "Hold Rook-Ceph at v1.19.x — v1.20 (Tentacle) is flaky; revisit after the bare-metal rebuild",
-      matchDatasources: ["docker"],
       matchPackageNames: [
         "ghcr.io/rook/rook-ceph",
         "ghcr.io/rook/rook-ceph-cluster",

--- a/cluster-apps/base/rook-ceph/cluster/ocirepository.yaml
+++ b/cluster-apps/base/rook-ceph/cluster/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.1
+    tag: v1.19.6
   url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/cluster-apps/base/rook-ceph/operator/ocirepository.yaml
+++ b/cluster-apps/base/rook-ceph/operator/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v1.20.1
+    tag: v1.19.6
   url: oci://ghcr.io/rook/rook-ceph


### PR DESCRIPTION
## Summary

- Downgrade rook-ceph operator and cluster charts from v1.20.1 → v1.19.6
- Pin Renovate to `<=1.19.6` to block auto-upgrades past this point

## Why

Rook-Ceph v1.20 (Tentacle) introduced the `ceph-csi-operator` transition which requires a separate `ceph-csi-drivers` Helm chart to create CSI ServiceAccounts/RBAC. Without it, the `rbd-nodeplugin-sa` SA is never created, the nodeplugin DaemonSet can only schedule on 1/3 nodes, and CSI attach/detach breaks on the other nodes.

Tracked upstream: https://github.com/rook/rook/issues/17644

Revisit after the bare-metal rebuild when we can properly onboard the new `ceph-csi-drivers` chart alongside the upgrade.

## Test plan

- [ ] `rook-ceph` and `rook-ceph-cluster` HelmReleases reconcile to v1.19.6
- [ ] `rbd-nodeplugin-sa` ServiceAccount recreated in `rook-ceph` namespace
- [ ] CSI nodeplugin DaemonSet schedules on all 3 nodes
- [ ] Pending pods on node02/node03 start successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)